### PR TITLE
Feature/anagrams trimming

### DIFF
--- a/FiveWordFinder.Extensions/Collections.cs
+++ b/FiveWordFinder.Extensions/Collections.cs
@@ -16,6 +16,18 @@
         }
 
         /// <summary>
+        /// Compares two collections returning only the elements that are present in both as an array.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="first"></param>
+        /// <param name="second"></param>
+        /// <returns></returns>
+        public static T[] IntersectWith<T>(this IEnumerable<T> first, IEnumerable<T> second)
+        {
+            return first.Where(x => second.Contains(x)).ToArray();
+        }
+
+        /// <summary>
         /// Creates a new array and copies the values from the stack in the original order of being added to the stack.
         /// </summary>
         /// <typeparam name="T"></typeparam>

--- a/FiveWordFinderConsole/Program.cs
+++ b/FiveWordFinderConsole/Program.cs
@@ -9,12 +9,14 @@ const string DefaultOutputFile = "Found_Cliques.txt";
 InitConsole();
 string filePath = ConsoleInputService.GetWordSourceFileName(DefaultSourceFile);
 var evaluator = ConsoleInputService.GetEvaluationStrategy();
+var writeToScreen = ConsoleInputService.GetShouldWriteToScreen();
+
 Console.WriteLine();
 try
 {
     var graph = GenerateWordGraph(filePath);
     var cliqueList = EvaluateGraph(graph, evaluator);
-    WriteCliques(DefaultOutputFile, cliqueList);
+    WriteCliques(DefaultOutputFile, cliqueList, writeToScreen);
 }
 catch(Exception ex)
 {
@@ -82,7 +84,7 @@ IEnumerable<FiveCharWord[]> EvaluateGraph(WordGraph graph, IGraphEvaluationStrat
     return results;
 }
 
-void WriteCliques(string outputFile, IEnumerable<FiveCharWord[]> cliqueList)
+void WriteCliques(string outputFile, IEnumerable<FiveCharWord[]> cliqueList, bool writeToScreen = false)
 {
     if (File.Exists(outputFile))
         File.Delete(outputFile);
@@ -93,7 +95,7 @@ void WriteCliques(string outputFile, IEnumerable<FiveCharWord[]> cliqueList)
             string strings = string.Join<FiveCharWord>("\t", wordList);
             writer.WriteLine(strings);
             
-            if (!Console.IsOutputRedirected)
+            if (writeToScreen && !Console.IsOutputRedirected)
                 Console.WriteLine(strings);
         }
         writer.Close();

--- a/FiveWordFinderConsole/Services/ConsoleInputService.cs
+++ b/FiveWordFinderConsole/Services/ConsoleInputService.cs
@@ -41,15 +41,15 @@ namespace FiveWordFinderConsole.Services
         public static IGraphEvaluationStrategy GetEvaluationStrategy()
         {
             Console.WriteLine("How should the word graph be evaluated?");
-            Console.WriteLine("1 = Find Loop In Series - (Default)");
-            Console.WriteLine("2 = Find Parallel ForEach");
+            Console.WriteLine("1 = Find Loop In Series");
+            Console.WriteLine("2 = Find Parallel ForEach - (Default)");
             bool inputValid = false;
-            int selection = 1;
+            int selection = 2;
             do
             {
                 string input = Console.ReadLine() ?? string.Empty;
                 if (string.IsNullOrWhiteSpace(input))
-                    input = "1";
+                    input = "2";
 
                 if (!(inputValid = int.TryParse(input, out selection)))
                 {
@@ -64,6 +64,26 @@ namespace FiveWordFinderConsole.Services
             };
 
             return strategy;
+        }
+
+        public static bool GetShouldWriteToScreen()
+        {
+            Console.WriteLine("Write found cliques to screen? (Y / N)");
+            Console.WriteLine("  Select this option to display the list to the console window as well as writing to file.");
+
+            bool result = false;
+            bool inputValid = false;
+            while (!inputValid)
+            {
+                var input = Console.ReadLine();
+                if (!string.IsNullOrEmpty(input))
+                {
+                    inputValid = true;
+                    result = input.ToUpper().First() == 'Y';
+                }    
+            }
+
+            return result;
         }
     }
 }

--- a/FiveWordFinderWpf/Model/WordDataView.cs
+++ b/FiveWordFinderWpf/Model/WordDataView.cs
@@ -9,19 +9,44 @@ using FiveWordFinder.WordProcessing.Model;
 
 namespace FiveWordFinderWpf.Model
 {
-    public class WordDataView
+    public class WordDataView : INotifyPropertyChanged
     {
-        public string Word { get; private set; }
+        private FiveCharWord _word;
+        public string Word { get { return _word.Word; } }
 
         public int LetterCount { get; private set; }
 
-        public int NeighborsCount { get; private set; }
+        public IReadOnlyList<string> Anagrams { get { return _word.Anagrams.Select(a => a.Word).ToList(); } }
 
-        public WordDataView(string word, int letterCount, int neighborsCount)
+        public int NeighborsCount { get { return _word.Neighbors.Count; } }
+
+        #region INotifyPropertyChanged
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = "")
         {
-            Word = word;
-            LetterCount = letterCount;
-            NeighborsCount = neighborsCount;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+        #endregion INotifyPropertyChanged
+
+        public WordDataView(FiveCharWord word)
+        {
+            _word = word;
+            LetterCount = _word.CountUniqueLetters;
+
+            _word.PropertyChanged += word_PropertyChanged;
+        }
+
+        private void word_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(_word.Anagrams))
+            {
+                OnPropertyChanged(nameof(Anagrams));
+            }
+            else if (e.PropertyName == nameof(_word.Neighbors))
+            {
+                OnPropertyChanged(nameof(NeighborsCount));
+            }
         }
     }
 }

--- a/FiveWordFinderWpf/View/GraphFileView.xaml
+++ b/FiveWordFinderWpf/View/GraphFileView.xaml
@@ -88,7 +88,7 @@
 
         <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width=".75*"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
@@ -178,6 +178,7 @@
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition SharedSizeGroup="col0"/>
                                     <ColumnDefinition SharedSizeGroup="col1"/>
+                                    <ColumnDefinition SharedSizeGroup="col2"/>
                                 </Grid.ColumnDefinitions>
                                 <StackPanel Grid.Column="0"
                                             Orientation="Horizontal">
@@ -187,7 +188,22 @@
                                                d:Text="Words"/>
                                 </StackPanel>
                                 <Grid Grid.Column="1"
-                                      Margin="10,0">
+                                      Margin="10,0,0,0">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition SharedSizeGroup="nTitle"/>
+                                        <ColumnDefinition SharedSizeGroup="nCount"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0"
+                                               FontWeight="Bold"
+                                               Text="Anagrams:"/>
+                                    <TextBlock Grid.Column="1"
+                                               Margin="0,0,5,0"
+                                               Text="{Binding Anagrams.Count}"
+                                               TextAlignment="Right"
+                                               d:Text="10"/>
+                                </Grid>
+                                <Grid Grid.Column="2"
+                                      Margin="10,0,0,0">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition SharedSizeGroup="nTitle"/>
                                         <ColumnDefinition SharedSizeGroup="nCount"/>

--- a/FiveWordFinderWpf/ViewModel/GraphFileViewModel.cs
+++ b/FiveWordFinderWpf/ViewModel/GraphFileViewModel.cs
@@ -128,7 +128,10 @@ namespace FiveWordFinderWpf.ViewModel
             generator.ProgressChanged += GraphGenerator_ProgressChanged;
             generator.WordAdded += (o, e) =>
             {
-                _applicationState.MainThreadDispatcher.Invoke(() => { WordsList.Add(new WordDataView(e.Word.Word, e.Word.CountUniqueLetters, e.Word.Neighbors.Count)); });
+                _applicationState.MainThreadDispatcher.Invoke(() => 
+                {
+                    WordsList.Add(new WordDataView(e.Word));
+                });
             };
         }
 

--- a/WordProcessing/Model/WordGraph.cs
+++ b/WordProcessing/Model/WordGraph.cs
@@ -7,26 +7,50 @@ using FiveWordFinder.WordProcessing.Events;
 
 namespace FiveWordFinder.WordProcessing.Model
 {
+    public enum GraphAddResults
+    {
+        AsNewWord,
+        AsAnagram,
+    }
+
     public class WordGraph
     {
-        public HashSet<FiveCharWord> WordSet { get; private set; }
+        private HashSet<FiveCharWord> _wordSet;
+        public IReadOnlySet<FiveCharWord> WordSet { get { return _wordSet; } }
+        private Dictionary<int, FiveCharWord> _wordsByMask;
+        public IReadOnlyDictionary<int, FiveCharWord> WordsByMask { get { return _wordsByMask; } }
 
         public int Count { get { return WordSet.Count; } }
         public int TotalNeighborsInGraph { get { return GetNeighborCount(); } }
 
         internal WordGraph()
         {
-            WordSet = new HashSet<FiveCharWord>();
+            _wordSet = new HashSet<FiveCharWord>();
+            _wordsByMask = new Dictionary<int, FiveCharWord>();
         }
 
         internal WordGraph(int capacity)
         {
-            WordSet = new HashSet<FiveCharWord>(capacity);
+            _wordSet = new HashSet<FiveCharWord>(capacity);
+            _wordsByMask = new Dictionary<int, FiveCharWord>(capacity);
         }
 
         private int GetNeighborCount()
         {
             return WordSet.Sum(v => v.Neighbors.Count);
+        }
+
+        public GraphAddResults AddWord(FiveCharWord word)
+        {
+            if (_wordsByMask.TryGetValue(word.CharBitMask, out var anagramParent))
+            {
+                anagramParent.AddAnagram(word);
+                return GraphAddResults.AsAnagram;
+            }
+            
+            _wordsByMask.Add(word.CharBitMask, word);
+            _wordSet.Add(word);
+            return GraphAddResults.AsNewWord;
         }
     }
 }

--- a/WordProcessing/Strategies/EvaluateGraphParallel.cs
+++ b/WordProcessing/Strategies/EvaluateGraphParallel.cs
@@ -60,14 +60,18 @@ namespace FiveWordFinder.WordProcessing.Strategies
                 wordStack.Push(word);
                 if (wordStack.Count == depth)
                 {
+                    var wordArrays = GetStackCombinations(wordStack);
                     lock (resultsLock)
                     {
-                        CliqueList.Add(wordStack.ToArrayFiFo());
+                        foreach (var a in wordArrays)
+                        {
+                            CliqueList.Add(a.ToArray());
+                        }
                     }
                 }
                 else
                 {
-                    recursiveFindCliques(depth, wordStack, clique.IntersectWithHashSet(word.Neighbors));
+                    recursiveFindCliques(depth, wordStack, clique.IntersectWith(word.Neighbors));
                 }
 
                 wordStack.Pop();

--- a/WordProcessing/Strategies/EvaluateGraphSeries.cs
+++ b/WordProcessing/Strategies/EvaluateGraphSeries.cs
@@ -42,11 +42,15 @@ namespace FiveWordFinder.WordProcessing.Strategies
                 wordStack.Push(word);
                 if (wordStack.Count == depth)
                 {
-                    CliqueList.Add(wordStack.ToArrayFiFo());
+                    var wordArrays = GetStackCombinations(wordStack);
+                    foreach (var a in wordArrays)
+                    {
+                        CliqueList.Add(a.ToArray());
+                    }
                 }
                 else
                 {
-                    recursiveFindCliques(depth, wordStack, clique.IntersectWithHashSet(word.Neighbors));
+                    recursiveFindCliques(depth, wordStack, clique.IntersectWith(word.Neighbors));
                 }
 
                 wordStack.Pop();

--- a/WordProcessing/Strategies/baseGraphEvaluatorStrategy.cs
+++ b/WordProcessing/Strategies/baseGraphEvaluatorStrategy.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
+using FiveWordFinder.Extensions;
 using FiveWordFinder.WordProcessing.Events;
 using FiveWordFinder.WordProcessing.Model;
 
@@ -64,6 +65,46 @@ namespace FiveWordFinder.WordProcessing.Strategies
         {
             CliqueList.Clear();
             OnProgressChanged(0, 0, 0, string.Empty);
+        }
+
+        protected IEnumerable<IEnumerable<FiveCharWord>> GetStackCombinations(Stack<FiveCharWord> wordStack)
+        {
+            var words = wordStack.ToArrayFiFo();
+            var groups = new List<IEnumerable<FiveCharWord>>();
+
+            foreach (var word in words)
+            {
+                List<FiveCharWord> group = new List<FiveCharWord>();
+                group.Add(word);
+                group.AddRange(word.Anagrams);
+                groups.Add(group);
+            }
+
+            return CartesianProducts(groups, 0);
+        }
+
+        protected IEnumerable<IEnumerable<FiveCharWord>> CartesianProducts(IList<IEnumerable<FiveCharWord>> lists, int depth, Stack<FiveCharWord>? product = null)
+        {
+            product = product ?? new Stack<FiveCharWord>();
+
+            foreach (var word in lists[depth])
+            {
+                product.Push(word);
+
+                if (product.Count == lists.Count)
+                {
+                    yield return product.ToArray().OrderBy(w => w);
+                }
+                else
+                {
+                    foreach (var pItem in CartesianProducts(lists, depth + 1, product))
+                    {
+                        yield return pItem;
+                    }
+                }
+
+                product.Pop();
+            }
         }
     }
 }


### PR DESCRIPTION
1. Improve Console App
  - Make writing output list an Option presented to user.
  - Change Default Strategy to Parallel

2. Add handling Anagrams on words to reduce number of iterations.
  - FiveCharWord
    - Add Anagrams set to FiveCharWord model.
    - Made Anagrams and Neighbors properties IReadOnlySets so control of adding is handled by the model Add methods
    - Implemented INotifyPropertyChanged so UI can update Anagram and Neighbor counts in real time.
  - WordGraph
    - Added internal Dictionary to store Words by a given bitmask for faster testing of Anagram signatures
    - Changed public properties of WordSet and new WordsByMask as readonly
    - Added method to AddWord to the graph. This tests and determines if the word is an Anagram of an existing word or a new word to add to the set.
  - GraphGenerator
    - Adjust graph loading and filling so words are first added to the graph before neighbors are found. This allows all anagrams tp be processed before potentially adding neighbors.
  - Evaluation Strategies
    - Changed to handle anagrams by building the potential words for a set of 5 and then getting the Cartesian Product of the sets for the current tree.